### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+zfsnap (1.11.1-5) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since stretch:
+    + Build-Depends: Drop versioned constraint on debhelper.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 14 Jun 2021 08:24:19 -0000
+
 zfsnap (1.11.1-4) unstable; urgency=low
 
   * Support GNU/kFreeBSD.  Closes: #742275.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: zfsnap
 Section: admin
 Priority: extra
 Maintainer: John Goerzen <jgoerzen@complete.org>
-Build-Depends: debhelper (>= 8.0.0), pandoc
+Build-Depends: debhelper, pandoc
 Standards-Version: 3.9.3
 Homepage: https://github.com/graudeejs/zfSnap
 Vcs-Git: https://github.com/jgoerzen/zfSnap.git
@@ -23,4 +23,3 @@ Description: Automatic snapshot creation and removal for ZFS
  Timestamp includes the date and time when the snapshot was created and
  TimeToLive (TTL) is the amount of time for the snapshot to stay alive before
  it's ready for deletion.
-


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/zfsnap/32865831-1619-4e55-8699-0afb1c068700.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/32865831-1619-4e55-8699-0afb1c068700/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/32865831-1619-4e55-8699-0afb1c068700/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/32865831-1619-4e55-8699-0afb1c068700/diffoscope)).
